### PR TITLE
🙈 Set query type as any

### DIFF
--- a/packages/example-express-ts/src/router.ts
+++ b/packages/example-express-ts/src/router.ts
@@ -1,22 +1,20 @@
-import { get, post, toRouter, wrap } from 'gutenpress'
+import { get, post, put, toRouter, wrap } from 'gutenpress'
 import { login } from './actions/login'
 import { authenticate } from './wrappers/authenticate'
 import { listOrders } from './actions/order/list'
-// import { getOrderById } from './actions/order/get'
+import { getOrderById } from './actions/order/get'
 import { createOrder } from './actions/order/create'
-// import { updateOrderById } from './actions/order/update'
+import { updateOrderById } from './actions/order/update'
 import { contactDetails } from './actions/contact-details'
 
-// TODO: add tests for types that ensure we scream if a method is placed in the wrong place
 export default toRouter([
   post('/login', login),
   wrap(authenticate, [
     // You can declare endpoints inline
     get('/order', listOrders),
-    // TODO: fix types for query
-    // get('/order/:id', getOrderById),
+    get('/order/:id', getOrderById),
     post('/order', createOrder),
-    // put('/order/:id', updateOrderById),
+    put('/order/:id', updateOrderById),
 
     // Or import them from somewhere else
     contactDetails,

--- a/packages/example-express-ts/src/wrappers/authenticate.ts
+++ b/packages/example-express-ts/src/wrappers/authenticate.ts
@@ -8,7 +8,7 @@ export type Token = {
 export const authenticate = ({
   headers,
 }: RequestParams): Token | UnauthorizedError => {
-  const [, token] = headers?.authorization.split(' ') || []
+  const [, token] = headers.authorization.split(' ') || []
   const [username, password] = Buffer.from(token, 'base64')
     .toString()
     .split(':')

--- a/packages/gutenpress/src/types.ts
+++ b/packages/gutenpress/src/types.ts
@@ -6,7 +6,8 @@ export interface RequestParams<
   Context = {},
   Method extends HTTPMethod = HTTPMethod
 > {
-  readonly query: Record<string, string>
+  // COMBAK: find a way to enforce values in the query object are strings
+  readonly query: any
   readonly body: Method extends 'GET' ? void : any
   readonly context: Context
   readonly headers: Record<string, string>


### PR DESCRIPTION
I couldn't find a way to enforce query values as strings without rendering the example useless